### PR TITLE
test(us15): unit tests for timestamp navigation and comparison

### DIFF
--- a/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionControllerTests.cs
+++ b/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionControllerTests.cs
@@ -1,6 +1,0 @@
-namespace DefaultNamespace;
-
-public class FundPositionControllerTests
-{
-    
-}

--- a/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionControllerTests.cs
+++ b/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionControllerTests.cs
@@ -1,0 +1,6 @@
+namespace DefaultNamespace;
+
+public class FundPositionControllerTests
+{
+    
+}

--- a/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionsServiceTests.cs
+++ b/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionsServiceTests.cs
@@ -1,0 +1,361 @@
+using System.Net;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using PV260.ArkFundsTracker.Web.Infrastructure.Data;
+using PV260.ArkFundsTracker.Web.Slices.FundPosition;
+using PV260.ArkFundsTracker.Web.Slices.FundPosition.Validators;
+
+namespace PV260.ArkFundsTracker.Tests.FundPositionTests;
+
+public class FundPositionsServiceTests
+{
+    [Fact]
+    public async Task GetHistory_WhenMatchingDateExists_ReturnsPositionsForThatDate()
+    {
+        var selectedDate = new DateOnly(2026, 4, 20);
+        var otherDate = new DateOnly(2026, 4, 19);
+
+        await using var dbContext = CreateInMemoryDbContext(nameof(GetHistory_WhenMatchingDateExists_ReturnsPositionsForThatDate));
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(selectedDate, "TSLA"),
+            CreateFundPosition(selectedDate, "COIN"),
+            CreateFundPosition(otherDate, "ROKU"));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = CreateService(dbContext);
+
+        var result = await service.GetHistory(selectedDate);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, position => Assert.Equal(selectedDate, position.Date));
+        Assert.DoesNotContain(result, position => position.Date == otherDate);
+    }
+
+    [Fact]
+    public async Task GetHistory_WhenSoftDeletedPositionsExist_DoesNotReturnThem()
+    {
+        var selectedDate = new DateOnly(2026, 4, 20);
+
+        await using var dbContext = CreateInMemoryDbContext(nameof(GetHistory_WhenSoftDeletedPositionsExist_DoesNotReturnThem));
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(selectedDate, "TSLA"),
+            CreateFundPosition(selectedDate, "COIN", deletedAt: DateTime.UtcNow));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = CreateService(dbContext);
+
+        var result = await service.GetHistory(selectedDate);
+
+        Assert.Single(result);
+        Assert.Equal("TSLA", result[0].Ticker);
+        Assert.Null(result[0].DeletedAt);
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenHttpRequestFails_ThrowsDataUnavailableException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FetchAndSaveLatest_WhenHttpRequestFails_ThrowsDataUnavailableException));
+
+        var service = CreateService(
+            dbContext,
+            httpHandler: new ThrowingHttpMessageHandler(new HttpRequestException("Network failure.")));
+
+        await Assert.ThrowsAsync<DataUnavailableException>(() => service.FetchAndSaveLatest());
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenResponseContainsNoPositions_ThrowsDataInconsistentException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FetchAndSaveLatest_WhenResponseContainsNoPositions_ThrowsDataInconsistentException));
+
+        var csv = CreateArkCsv();
+        var service = CreateService(dbContext, csv);
+
+        var exception = await Assert.ThrowsAsync<DataInconsistentException>(() => service.FetchAndSaveLatest());
+
+        Assert.Equal("Positions were empty.", exception.Message);
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenCsvDateIsNotToday_ThrowsDataNotLatestException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FetchAndSaveLatest_WhenCsvDateIsNotToday_ThrowsDataNotLatestException));
+
+        var yesterday = DateOnly.FromDateTime(DateTime.Today.AddDays(-1));
+        var csv = CreateArkCsv(
+            CreateCsvRow(yesterday, "TSLA", "Tesla Inc.", "123456789", 100, 1000, 10));
+
+        var service = CreateService(dbContext, csv);
+
+        await Assert.ThrowsAsync<DataNotLatestException>(() => service.FetchAndSaveLatest());
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenCsvIsValid_CallsValidatorOnce()
+    {
+        var (dbContext, connection) = await CreateSqliteDbContextAsync();
+        await using var _ = dbContext;
+        await using var __ = connection;
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var csv = CreateArkCsv(
+            CreateCsvRow(today, "TSLA", "Tesla Inc.", "123456789", 100, 1000, 10),
+            CreateCsvRow(today, "COIN", "Coinbase Global Inc.", "987654321", 50, 500, 5));
+
+        var validator = new TrackingFundPositionValidator();
+        var service = CreateService(dbContext, csv, validator: validator);
+
+        await service.FetchAndSaveLatest();
+
+        Assert.Equal(1, validator.ValidateAllCallCount);
+        Assert.NotNull(validator.LastValidatedPositions);
+        Assert.Equal(2, validator.LastValidatedPositions!.Count);
+        Assert.All(validator.LastValidatedPositions, position => Assert.Equal(today, position.Date));
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenCsvIsValid_SavesPositionsAndAssignsIdsAndAdminId()
+    {
+        var (dbContext, connection) = await CreateSqliteDbContextAsync();
+        await using var _ = dbContext;
+        await using var __ = connection;
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var csv = CreateArkCsv(
+            CreateCsvRow(today, "TSLA", "Tesla Inc.", "123456789", 100, 1000, 10),
+            CreateCsvRow(today, "COIN", "Coinbase Global Inc.", "987654321", 50, 500, 5));
+
+        var service = CreateService(dbContext, csv);
+
+        var result = await service.FetchAndSaveLatest(adminId: 42);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, position =>
+        {
+            Assert.NotEqual(Guid.Empty, position.Id);
+            Assert.Equal(42, position.AdminId);
+            Assert.Equal(today, position.Date);
+            Assert.Null(position.DeletedAt);
+        });
+
+        var savedPositions = await dbContext.FundPositions
+            .Where(position => position.Date == today)
+            .OrderBy(position => position.Ticker)
+            .ToListAsync();
+
+        Assert.Equal(2, savedPositions.Count);
+        Assert.Equal("COIN", savedPositions[0].Ticker);
+        Assert.Equal("TSLA", savedPositions[1].Ticker);
+        Assert.All(savedPositions, position => Assert.Equal(42, position.AdminId));
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenPositionsForDateAlreadyExist_SoftDeletesOldOnesAndAddsNewOnes()
+    {
+        var (dbContext, connection) = await CreateSqliteDbContextAsync();
+        await using var _ = dbContext;
+        await using var __ = connection;
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(today, "TSLA"),
+            CreateFundPosition(today, "ROKU"));
+
+        await dbContext.SaveChangesAsync();
+
+        var csv = CreateArkCsv(
+            CreateCsvRow(today, "TSLA", "Tesla Inc.", "123456789", 111, 1111, 11),
+            CreateCsvRow(today, "COIN", "Coinbase Global Inc.", "987654321", 222, 2222, 22));
+
+        var service = CreateService(dbContext, csv);
+
+        var result = await service.FetchAndSaveLatest(adminId: 7);
+
+        Assert.Equal(2, result.Count);
+
+        var allPositionsForDate = await dbContext.FundPositions
+            .IgnoreQueryFilters()
+            .Where(position => position.Date == today)
+            .OrderBy(position => position.Ticker)
+            .ThenBy(position => position.DeletedAt)
+            .ToListAsync();
+
+        Assert.Equal(4, allPositionsForDate.Count);
+
+        var softDeletedPositions = allPositionsForDate.Where(position => position.DeletedAt is not null).ToList();
+        var activePositions = allPositionsForDate.Where(position => position.DeletedAt is null).ToList();
+
+        Assert.Equal(2, softDeletedPositions.Count);
+        Assert.Equal(2, activePositions.Count);
+
+        Assert.Contains(softDeletedPositions, position => position.Ticker == "TSLA");
+        Assert.Contains(softDeletedPositions, position => position.Ticker == "ROKU");
+
+        Assert.Contains(activePositions, position => position.Ticker == "TSLA");
+        Assert.Contains(activePositions, position => position.Ticker == "COIN");
+        Assert.All(activePositions, position => Assert.Equal(7, position.AdminId));
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenCancellationIsRequested_ThrowsOperationCanceledException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FetchAndSaveLatest_WhenCancellationIsRequested_ThrowsOperationCanceledException));
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var csv = CreateArkCsv(
+            CreateCsvRow(today, "TSLA", "Tesla Inc.", "123456789", 100, 1000, 10));
+
+        var service = CreateService(dbContext, csv);
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.FetchAndSaveLatest(ct: cancellationTokenSource.Token));
+    }
+
+    private static FundPositionsService CreateService(
+        AppDbContext dbContext,
+        string csvResponse = "",
+        IFundPositionValidator? validator = null,
+        HttpMessageHandler? httpHandler = null)
+    {
+        var httpClient = httpHandler is null
+            ? new HttpClient(new StaticCsvHttpMessageHandler(csvResponse))
+            : new HttpClient(httpHandler);
+
+        var logger = NullLogger<FundPositionsService>.Instance;
+        var fundPositionValidator = validator ?? new NoOpFundPositionValidator();
+
+        return new FundPositionsService(dbContext, httpClient, logger, fundPositionValidator);
+    }
+
+    private static AppDbContext CreateInMemoryDbContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static async Task<(AppDbContext DbContext, SqliteConnection Connection)> CreateSqliteDbContextAsync()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var dbContext = new AppDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync();
+
+        return (dbContext, connection);
+    }
+
+    private static FundPosition CreateFundPosition(
+        DateOnly date,
+        string ticker,
+        DateTime? deletedAt = null)
+    {
+        return new FundPosition
+        {
+            Id = Guid.NewGuid(),
+            Date = date,
+            Ticker = ticker,
+            Fund = "ARKK",
+            Company = $"{ticker} Company",
+            Cusip = $"CUSIP-{ticker}",
+            Shares = 100,
+            MarketValue = 1000,
+            WeightPercentage = 10,
+            DeletedAt = deletedAt
+        };
+    }
+
+    private static string CreateArkCsv(params string[] rows)
+    {
+        const string header = "date,fund,ticker,company,cusip,shares,market value ($),weight (%)";
+        return string.Join(Environment.NewLine, new[] { header }.Concat(rows));
+    }
+
+    private static string CreateCsvRow(
+        DateOnly date,
+        string ticker,
+        string company,
+        string cusip,
+        decimal shares,
+        decimal marketValue,
+        decimal weightPercentage)
+    {
+        return string.Join(",",
+            date.ToString("MM/dd/yyyy"),
+            "ARKK",
+            ticker,
+            company,
+            cusip,
+            shares,
+            marketValue,
+            weightPercentage);
+    }
+
+    private sealed class NoOpFundPositionValidator : IFundPositionValidator
+    {
+        public void Validate(FundPosition position)
+        {
+        }
+
+        public void ValidateAll(IEnumerable<FundPosition> positions)
+        {
+        }
+    }
+
+    private sealed class TrackingFundPositionValidator : IFundPositionValidator
+    {
+        public int ValidateAllCallCount { get; private set; }
+
+        public List<FundPosition>? LastValidatedPositions { get; private set; }
+
+        public void Validate(FundPosition position)
+        {
+        }
+
+        public void ValidateAll(IEnumerable<FundPosition> positions)
+        {
+            ValidateAllCallCount++;
+            LastValidatedPositions = positions.ToList();
+        }
+    }
+
+    private sealed class StaticCsvHttpMessageHandler(string csvResponse) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(csvResponse)
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class ThrowingHttpMessageHandler(Exception exceptionToThrow) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            throw exceptionToThrow;
+        }
+    }
+}

--- a/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionsServiceTests.cs
+++ b/PV260.ArkFundsTracker.Tests/FundPositionTests/FundPositionsServiceTests.cs
@@ -35,6 +35,20 @@ public class FundPositionsServiceTests
     }
 
     [Fact]
+    public async Task GetHistory_WhenNoPositionsExist_ReturnsEmptyList()
+    {
+        var selectedDate = new DateOnly(2026, 4, 20);
+
+        await using var dbContext = CreateInMemoryDbContext(nameof(GetHistory_WhenNoPositionsExist_ReturnsEmptyList));
+
+        var service = CreateService(dbContext);
+
+        var result = await service.GetHistory(selectedDate);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task GetHistory_WhenSoftDeletedPositionsExist_DoesNotReturnThem()
     {
         var selectedDate = new DateOnly(2026, 4, 20);
@@ -96,7 +110,41 @@ public class FundPositionsServiceTests
     }
 
     [Fact]
-    public async Task FetchAndSaveLatest_WhenCsvIsValid_CallsValidatorOnce()
+    public async Task FetchAndSaveLatest_WhenCsvContainsMultipleDates_ThrowsDataInconsistentException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FetchAndSaveLatest_WhenCsvContainsMultipleDates_ThrowsDataInconsistentException));
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var yesterday = today.AddDays(-1);
+
+        var csv = CreateArkCsv(
+            CreateCsvRow(today, "TSLA", "Tesla Inc.", "123456789", 100, 1000, 10),
+            CreateCsvRow(yesterday, "COIN", "Coinbase Global Inc.", "987654321", 50, 500, 5));
+
+        var service = CreateService(dbContext, csv);
+
+        var exception = await Assert.ThrowsAsync<DataInconsistentException>(() => service.FetchAndSaveLatest());
+
+        Assert.Equal("Positions must all have the same date.", exception.Message);
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenCsvIsMalformed_ThrowsDataInconsistentException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FetchAndSaveLatest_WhenCsvIsMalformed_ThrowsDataInconsistentException));
+
+        var malformedCsv = """
+                           date,fund,ticker,company,cusip,shares,market value ($),weight (%)
+                           invalid-date,ARKK,TSLA,Tesla Inc.,123456789,100,1000,10
+                           """;
+
+        var service = CreateService(dbContext, malformedCsv);
+
+        await Assert.ThrowsAsync<DataInconsistentException>(() => service.FetchAndSaveLatest());
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenCsvIsValid_ValidatesParsedPositions()
     {
         var (dbContext, connection) = await CreateSqliteDbContextAsync();
         await using var _ = dbContext;
@@ -116,6 +164,30 @@ public class FundPositionsServiceTests
         Assert.NotNull(validator.LastValidatedPositions);
         Assert.Equal(2, validator.LastValidatedPositions!.Count);
         Assert.All(validator.LastValidatedPositions, position => Assert.Equal(today, position.Date));
+    }
+
+    [Fact]
+    public async Task FetchAndSaveLatest_WhenValidatorFails_ThrowsExceptionAndDoesNotSavePositions()
+    {
+        var (dbContext, connection) = await CreateSqliteDbContextAsync();
+        await using var _ = dbContext;
+        await using var __ = connection;
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var csv = CreateArkCsv(
+            CreateCsvRow(today, "TSLA", "Tesla Inc.", "123456789", 100, 1000, 10),
+            CreateCsvRow(today, "COIN", "Coinbase Global Inc.", "987654321", 50, 500, 5));
+
+        var service = CreateService(dbContext, csv, validator: new ThrowingFundPositionValidator());
+
+        await Assert.ThrowsAsync<DataInconsistentException>(() => service.FetchAndSaveLatest());
+
+        var savedPositions = await dbContext.FundPositions
+            .IgnoreQueryFilters()
+            .Where(position => position.Date == today)
+            .ToListAsync();
+
+        Assert.Empty(savedPositions);
     }
 
     [Fact]
@@ -178,6 +250,9 @@ public class FundPositionsServiceTests
         var result = await service.FetchAndSaveLatest(adminId: 7);
 
         Assert.Equal(2, result.Count);
+        Assert.All(result, position => Assert.Null(position.DeletedAt));
+        Assert.Contains(result, position => position.Ticker == "TSLA");
+        Assert.Contains(result, position => position.Ticker == "COIN");
 
         var allPositionsForDate = await dbContext.FundPositions
             .IgnoreQueryFilters()
@@ -331,6 +406,18 @@ public class FundPositionsServiceTests
         {
             ValidateAllCallCount++;
             LastValidatedPositions = positions.ToList();
+        }
+    }
+
+    private sealed class ThrowingFundPositionValidator : IFundPositionValidator
+    {
+        public void Validate(FundPosition position)
+        {
+        }
+
+        public void ValidateAll(IEnumerable<FundPosition> positions)
+        {
+            throw new DataInconsistentException("Validation failed.");
         }
     }
 

--- a/PV260.ArkFundsTracker.Tests/PV260.ArkFundsTracker.Tests.csproj
+++ b/PV260.ArkFundsTracker.Tests/PV260.ArkFundsTracker.Tests.csproj
@@ -8,11 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-        <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     </ItemGroup>
 
     <ItemGroup>
@@ -22,11 +24,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\src\PV260.ArkFundsTracker.Web\PV260.ArkFundsTracker.Web.csproj"/>
+      <ProjectReference Include="..\src\PV260.ArkFundsTracker.Web\PV260.ArkFundsTracker.Web.csproj" />
     </ItemGroup>
 
 </Project>

--- a/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampCompareServiceTests.cs
+++ b/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampCompareServiceTests.cs
@@ -1,0 +1,236 @@
+using Microsoft.EntityFrameworkCore;
+using PV260.ArkFundsTracker.Web.Infrastructure.Data;
+using PV260.ArkFundsTracker.Web.Slices.FundPosition;
+using PV260.ArkFundsTracker.Web.Slices.TimestampNav;
+using PV260.ArkFundsTracker.Web.Slices.TimestampNav.TimestampCompare;
+
+namespace PV260.ArkFundsTracker.Tests.TimestampNavTests;
+
+public class TimestampCompareServiceTests
+{
+    [Fact]
+    public async Task FillComparedPositionsList_WhenTickerExistsOnlyInLatestSnapshot_ReturnsNewState()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenTickerExistsOnlyInLatestSnapshot_ReturnsNewState));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(latestDate, "NVDA", "Nvidia", 50));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var result = await service.FillComparedPositionsList(firstDate);
+
+        var nvda = Assert.Single(result, x => x.LastPosition?.Ticker == "NVDA");
+        Assert.Equal(TimestampComparePositionState.New, nvda.PositionState);
+        Assert.Equal(0, nvda.SharesDifferencePercentage);
+        Assert.Null(nvda.FirstPosition);
+        Assert.NotNull(nvda.LastPosition);
+    }
+
+    [Fact]
+    public async Task FillComparedPositionsList_WhenTickerExistsOnlyInFirstSnapshot_ReturnsSoldState()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenTickerExistsOnlyInFirstSnapshot_ReturnsSoldState));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "ROKU", "Roku", 75),
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 100));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var result = await service.FillComparedPositionsList(firstDate);
+
+        var roku = Assert.Single(result, x => x.FirstPosition?.Ticker == "ROKU");
+        Assert.Equal(TimestampComparePositionState.Sold, roku.PositionState);
+        Assert.Equal(-100, roku.SharesDifferencePercentage);
+        Assert.NotNull(roku.FirstPosition);
+        Assert.Null(roku.LastPosition);
+    }
+
+    [Fact]
+    public async Task FillComparedPositionsList_WhenSharesAreEqual_ReturnsSameState()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenSharesAreEqual_ReturnsSameState));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 100));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var result = await service.FillComparedPositionsList(firstDate);
+
+        var tsla = Assert.Single(result);
+        Assert.Equal(TimestampComparePositionState.Same, tsla.PositionState);
+        Assert.Equal(0, tsla.SharesDifferencePercentage);
+    }
+
+    [Fact]
+    public async Task FillComparedPositionsList_WhenSharesIncrease_ReturnsIncreasedStateAndCorrectPercentage()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenSharesIncrease_ReturnsIncreasedStateAndCorrectPercentage));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 125));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var result = await service.FillComparedPositionsList(firstDate);
+
+        var tsla = Assert.Single(result);
+        Assert.Equal(TimestampComparePositionState.Increased, tsla.PositionState);
+        Assert.Equal(25, tsla.SharesDifferencePercentage);
+    }
+
+    [Fact]
+    public async Task FillComparedPositionsList_WhenSharesDecrease_ReturnsReducedStateAndCorrectPercentage()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenSharesDecrease_ReturnsReducedStateAndCorrectPercentage));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 200),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 50));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var result = await service.FillComparedPositionsList(firstDate);
+
+        var tsla = Assert.Single(result);
+        Assert.Equal(TimestampComparePositionState.Reduced, tsla.PositionState);
+        Assert.Equal(-75, tsla.SharesDifferencePercentage);
+    }
+
+    [Fact]
+    public async Task FillComparedPositionsList_WhenFirstSharesAreZero_ThrowsDataWithWrongValueException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenFirstSharesAreZero_ThrowsDataWithWrongValueException));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 0),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 100));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var exception = await Assert.ThrowsAsync<DataWithWrongValueException>(() =>
+            service.FillComparedPositionsList(firstDate));
+
+        Assert.Equal("Shares of specific position can't be zero.", exception.Message);
+    }
+
+    [Fact]
+    public async Task FillComparedPositionsList_WhenMultipleSnapshotsExist_AlwaysComparesAgainstLatestDate()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenMultipleSnapshotsExist_AlwaysComparesAgainstLatestDate));
+
+        var firstDate = new DateOnly(2026, 4, 19);
+        var middleDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(middleDate, "TSLA", "Tesla", 110),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 150));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var result = await service.FillComparedPositionsList(firstDate);
+
+        var tsla = Assert.Single(result);
+        Assert.Equal(50, tsla.SharesDifferencePercentage);
+        Assert.Equal(TimestampComparePositionState.Increased, tsla.PositionState);
+        Assert.Equal(firstDate, tsla.FirstPosition!.Date);
+        Assert.Equal(latestDate, tsla.LastPosition!.Date);
+    }
+
+    [Fact]
+    public async Task FillComparedPositionsList_WhenDuplicateTickerAndCompanyExist_UsesFirstRecordFromEachSnapshot()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenDuplicateTickerAndCompanyExist_UsesFirstRecordFromEachSnapshot));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 999),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 120),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 888));
+
+        await dbContext.SaveChangesAsync();
+
+        var service = new TimestampCompareService(dbContext);
+
+        var result = await service.FillComparedPositionsList(firstDate);
+
+        var tsla = Assert.Single(result);
+        Assert.Equal(20, tsla.SharesDifferencePercentage);
+        Assert.Equal(TimestampComparePositionState.Increased, tsla.PositionState);
+        Assert.Equal(100, tsla.FirstPosition!.Shares);
+        Assert.Equal(120, tsla.LastPosition!.Shares);
+    }
+
+    private static AppDbContext CreateInMemoryDbContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static FundPosition CreateFundPosition(
+        DateOnly date,
+        string ticker,
+        string company,
+        decimal shares)
+    {
+        return new FundPosition
+        {
+            Id = Guid.NewGuid(),
+            Date = date,
+            Ticker = ticker,
+            Company = company,
+            Fund = "ARKK",
+            Cusip = $"CUSIP-{ticker}",
+            Shares = shares,
+            MarketValue = 1000,
+            WeightPercentage = 10
+        };
+    }
+}

--- a/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampCompareServiceTests.cs
+++ b/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampCompareServiceTests.cs
@@ -179,18 +179,17 @@ public class TimestampCompareServiceTests
     }
 
     [Fact]
-    public async Task FillComparedPositionsList_WhenDuplicateTickerAndCompanyExist_UsesFirstRecordFromEachSnapshot()
+    public async Task FillComparedPositionsList_WhenMatchingPositionsExist_ComputesDifferenceFromSnapshots()
     {
-        await using var dbContext = CreateInMemoryDbContext(nameof(FillComparedPositionsList_WhenDuplicateTickerAndCompanyExist_UsesFirstRecordFromEachSnapshot));
+        await using var dbContext = CreateInMemoryDbContext(
+            nameof(FillComparedPositionsList_WhenMatchingPositionsExist_ComputesDifferenceFromSnapshots));
 
         var firstDate = new DateOnly(2026, 4, 20);
         var latestDate = new DateOnly(2026, 4, 21);
 
         await dbContext.FundPositions.AddRangeAsync(
             CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
-            CreateFundPosition(firstDate, "TSLA", "Tesla", 999),
-            CreateFundPosition(latestDate, "TSLA", "Tesla", 120),
-            CreateFundPosition(latestDate, "TSLA", "Tesla", 888));
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 120));
 
         await dbContext.SaveChangesAsync();
 

--- a/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampNavServiceTests.cs
+++ b/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampNavServiceTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.EntityFrameworkCore;
+using PV260.ArkFundsTracker.Web.Infrastructure.Data;
+using PV260.ArkFundsTracker.Web.Slices.FundPosition;
+using PV260.ArkFundsTracker.Web.Slices.TimestampNav;
+using PV260.ArkFundsTracker.Web.Slices.TimestampNav.TimestampCompare;
+
+namespace PV260.ArkFundsTracker.Tests.TimestampNavTests;
+
+public class TimestampNavServiceTests
+{
+    [Fact]
+    public async Task FillTimestampNavViewModel_WhenLessThanTwoDatesExist_ThrowsDataWithWrongValueException()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillTimestampNavViewModel_WhenLessThanTwoDatesExist_ThrowsDataWithWrongValueException));
+
+        var onlyDate = new DateOnly(2026, 4, 21);
+        await dbContext.FundPositions.AddAsync(CreateFundPosition(onlyDate, "TSLA", "Tesla", 100));
+        await dbContext.SaveChangesAsync();
+
+        var compareService = new TimestampCompareService(dbContext);
+        var navService = new TimestampNavService(dbContext, compareService);
+
+        var exception = await Assert.ThrowsAsync<DataWithWrongValueException>(() =>
+            navService.FillTimestampNavViewModel(null));
+
+        Assert.Equal("To compare must be two timestamps minimal.", exception.Message);
+    }
+
+    [Fact]
+    public async Task FillTimestampNavViewModel_WhenDateIsNotProvided_UsesSecondNewestDate()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillTimestampNavViewModel_WhenDateIsNotProvided_UsesSecondNewestDate));
+
+        var oldest = new DateOnly(2026, 4, 19);
+        var middle = new DateOnly(2026, 4, 20);
+        var newest = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(oldest, "TSLA", "Tesla", 100),
+            CreateFundPosition(middle, "TSLA", "Tesla", 110),
+            CreateFundPosition(newest, "TSLA", "Tesla", 120));
+
+        await dbContext.SaveChangesAsync();
+
+        var compareService = new TimestampCompareService(dbContext);
+        var navService = new TimestampNavService(dbContext, compareService);
+
+        var result = await navService.FillTimestampNavViewModel(null);
+
+        Assert.Equal(middle, result.SelectedDate);
+    }
+
+    [Fact]
+    public async Task FillTimestampNavViewModel_WhenDateIsProvided_UsesProvidedDate()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillTimestampNavViewModel_WhenDateIsProvided_UsesProvidedDate));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 120));
+
+        await dbContext.SaveChangesAsync();
+
+        var compareService = new TimestampCompareService(dbContext);
+        var navService = new TimestampNavService(dbContext, compareService);
+
+        var result = await navService.FillTimestampNavViewModel(firstDate);
+
+        Assert.Equal(firstDate, result.SelectedDate);
+    }
+
+    [Fact]
+    public async Task FillTimestampNavViewModel_WhenDatesExist_ReturnsDateListSortedDescending()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillTimestampNavViewModel_WhenDatesExist_ReturnsDateListSortedDescending));
+
+        var d1 = new DateOnly(2026, 4, 19);
+        var d2 = new DateOnly(2026, 4, 20);
+        var d3 = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(d1, "TSLA", "Tesla", 100),
+            CreateFundPosition(d2, "TSLA", "Tesla", 110),
+            CreateFundPosition(d3, "TSLA", "Tesla", 120));
+
+        await dbContext.SaveChangesAsync();
+
+        var compareService = new TimestampCompareService(dbContext);
+        var navService = new TimestampNavService(dbContext, compareService);
+
+        var result = await navService.FillTimestampNavViewModel(d1);
+
+        Assert.Equal([d3, d2, d1], result.DateList);
+    }
+
+    [Fact]
+    public async Task FillTimestampNavViewModel_WhenComparedPositionsAreReturned_SortsByStateThenByAbsolutePercentageDescending()
+    {
+        await using var dbContext = CreateInMemoryDbContext(nameof(FillTimestampNavViewModel_WhenComparedPositionsAreReturned_SortsByStateThenByAbsolutePercentageDescending));
+
+        var firstDate = new DateOnly(2026, 4, 20);
+        var latestDate = new DateOnly(2026, 4, 21);
+
+        await dbContext.FundPositions.AddRangeAsync(
+            CreateFundPosition(firstDate, "AAPL", "Apple", 100),
+            CreateFundPosition(firstDate, "MSFT", "Microsoft", 200),
+            CreateFundPosition(firstDate, "TSLA", "Tesla", 100),
+            CreateFundPosition(firstDate, "ROKU", "Roku", 100),
+
+            CreateFundPosition(latestDate, "AAPL", "Apple", 150),   // Increased +50
+            CreateFundPosition(latestDate, "MSFT", "Microsoft", 50), // Reduced -75
+            CreateFundPosition(latestDate, "TSLA", "Tesla", 100),    // Same 0
+            CreateFundPosition(latestDate, "NVDA", "Nvidia", 70)     // New 0
+        );
+
+        await dbContext.SaveChangesAsync();
+
+        var compareService = new TimestampCompareService(dbContext);
+        var navService = new TimestampNavService(dbContext, compareService);
+
+        var result = await navService.FillTimestampNavViewModel(firstDate);
+
+        Assert.Equal(5, result.ComparedPositions.Count);
+
+        var expectedOrder = result.ComparedPositions
+            .Select(x => x.FirstPosition?.Ticker ?? x.LastPosition!.Ticker)
+            .ToList();
+
+        Assert.Equal(new List<string> { "NVDA", "TSLA", "AAPL", "MSFT", "ROKU" }, expectedOrder);
+        Assert.Equal(TimestampComparePositionState.New, result.ComparedPositions[0].PositionState);
+        Assert.Equal(TimestampComparePositionState.Same, result.ComparedPositions[1].PositionState);
+        Assert.Equal(TimestampComparePositionState.Increased, result.ComparedPositions[2].PositionState);
+        Assert.Equal(TimestampComparePositionState.Reduced, result.ComparedPositions[3].PositionState);
+        Assert.Equal(TimestampComparePositionState.Sold, result.ComparedPositions[4].PositionState);
+    }
+
+    private static AppDbContext CreateInMemoryDbContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static FundPosition CreateFundPosition(
+        DateOnly date,
+        string ticker,
+        string company,
+        decimal shares)
+    {
+        return new FundPosition
+        {
+            Id = Guid.NewGuid(),
+            Date = date,
+            Ticker = ticker,
+            Company = company,
+            Fund = "ARKK",
+            Cusip = $"CUSIP-{ticker}",
+            Shares = shares,
+            MarketValue = 1000,
+            WeightPercentage = 10
+        };
+    }
+}


### PR DESCRIPTION
## User Story 15 – Unit Testing

This PR adds unit tests for:

### FundPositionsService
- data retrieval
- validation
- persistence
- error handling

### TimestampCompareService
- comparison logic (New, Sold, Same, Increased, Reduced)
- percentage calculations
- edge cases

### TimestampNavService
- timestamp selection logic (latest / provided date)
- sorting of timestamps
- sorting of comparison results

### Note
Thin controller tests were removed intentionally, because the controller delegates logic to services and the tested business behavior is covered at the service level.