### PR TITLE
User Story 5: Project Documentation Foundation (Markdown)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This document defines the workflow and conventions for contributing to the proje
 
 Branches must follow this format:
 
-us<NUMBER>-short-description
+`us<NUMBER>-short-description`
 
 Examples:
 - us5-project-documentation
@@ -18,7 +18,7 @@ Examples:
 
 Commit messages must follow:
 
-<type>(us<NUMBER>): message
+`<type>(us<NUMBER>): message`
 
 Allowed types:
 - feat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Examples:
 - us5-project-documentation
 - us14-unit-testing-ingestion
 
+---
+
 ## Commit Message Format
 
 Commit messages must follow:
@@ -34,6 +36,8 @@ Allowed types:
 Example:
 feat(us10): add CI workflow
 
+---
+
 ## Workflow
 
 1. Create a branch from `milestone-X` or `main`
@@ -41,6 +45,8 @@ feat(us10): add CI workflow
 3. Write/update tests
 4. Run tests locally
 5. Create a Pull Request
+
+---
 
 ## Pull Requests
 
@@ -54,12 +60,16 @@ PR should include:
 - Why it was implemented
 - Any limitations
 
+---
+
 ## Code Style
 
-- Follow existing project structure
+- Follow the existing project structure
 - Keep methods small and readable
 - Use meaningful names
 - Avoid unnecessary complexity
+
+---
 
 ## Testing
 
@@ -71,11 +81,15 @@ Run tests:
 
 dotnet test
 
+---
+
 ## Pre-push Checks
 
 Before pushing:
 - Tests must pass
 - Code should compile without warnings
+
+---
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing Guide
+
+This document defines the workflow and conventions for contributing to the project.
+
+---
+
+## Branch Naming
+
+Branches must follow this format:
+
+```
+us<NUMBER>-short-description
+```
+
+Examples:
+- us5-project-documentation
+- us14-unit-testing-ingestion
+
+---
+
+## Commit Message Format
+
+Commit messages must follow:
+
+```
+<type>(us<NUMBER>): message
+```
+
+Allowed types:
+- feat
+- fix
+- refactor
+- docs
+- style
+- test
+- chore
+- ci
+- build
+- perf
+- revert
+
+Example:
+
+```
+feat(us5): add project documentation
+```
+
+---
+
+## Workflow
+
+1. Create a branch from `milestone-X` or `main`
+2. Implement changes
+3. Write/update tests
+4. Run tests locally
+5. Create Pull Request
+
+---
+
+## Pull Requests
+
+Requirements:
+- At least 1 approval
+- All tests must pass
+- Clear description of changes
+
+PR should include:
+- What was implemented
+- Why it was implemented
+- Any limitations
+
+---
+
+## Code Style
+
+- Follow existing project structure
+- Keep methods small and readable
+- Use meaningful names
+- Avoid unnecessary complexity
+
+---
+
+## Testing
+
+- Every new feature should include tests
+- Tests must pass before pushing
+- Use xUnit framework
+
+Run tests:
+
+```sh
+dotnet test
+```
+
+---
+
+## Pre-push Checks
+
+Before pushing:
+- Tests must pass
+- Code should compile without warnings
+
+---
+
+## Notes
+
+- Do not commit secrets or sensitive data
+- Keep changes focused and minimal
+- Documentation updates are part of the contribution  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,29 +2,21 @@
 
 This document defines the workflow and conventions for contributing to the project.
 
----
-
 ## Branch Naming
 
 Branches must follow this format:
 
-```
 us<NUMBER>-short-description
-```
 
 Examples:
 - us5-project-documentation
 - us14-unit-testing-ingestion
 
----
-
 ## Commit Message Format
 
 Commit messages must follow:
 
-```
 <type>(us<NUMBER>): message
-```
 
 Allowed types:
 - feat
@@ -40,12 +32,7 @@ Allowed types:
 - revert
 
 Example:
-
-```
-feat(us5): add project documentation
-```
-
----
+feat(us10): add CI workflow
 
 ## Workflow
 
@@ -53,9 +40,7 @@ feat(us5): add project documentation
 2. Implement changes
 3. Write/update tests
 4. Run tests locally
-5. Create Pull Request
-
----
+5. Create a Pull Request
 
 ## Pull Requests
 
@@ -69,16 +54,12 @@ PR should include:
 - Why it was implemented
 - Any limitations
 
----
-
 ## Code Style
 
 - Follow existing project structure
 - Keep methods small and readable
 - Use meaningful names
 - Avoid unnecessary complexity
-
----
 
 ## Testing
 
@@ -88,11 +69,7 @@ PR should include:
 
 Run tests:
 
-```sh
 dotnet test
-```
-
----
 
 ## Pre-push Checks
 
@@ -100,10 +77,8 @@ Before pushing:
 - Tests must pass
 - Code should compile without warnings
 
----
-
 ## Notes
 
 - Do not commit secrets or sensitive data
 - Keep changes focused and minimal
-- Documentation updates are part of the contribution  
+- Documentation updates are part of the contribution

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The application follows a vertical slice architecture and focuses on clean separ
 
 Repository containing group project of team-1.
 
-> Built with **.NET 10** (SDK **10.0.100**, as pinned in `global.json`)
+> Built with **.NET 10**
 
 ---
 
@@ -89,8 +89,8 @@ If needed, you can still override this value using `ConnectionStrings__Default` 
 
 Use the sample file and create your local `.env`:
 
-    macOS/Linux: cp .env.example .env
-    PowerShell: Copy-Item .env.example .env
+#### Windows (PowerShell)
+    Copy-Item .env.example .env
 
 `.env` is used by Docker Compose to configure:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ If needed, you can still override this value using `ConnectionStrings__Default` 
 
 Use the sample file and create your local `.env`:
 
-    Copy-Item .env.example .env
+    macOS/Linux: cp .env.example .env
+    PowerShell: Copy-Item .env.example .env
 
 `.env` is used by Docker Compose to configure:
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,40 @@
-# PV260 group project
+# PV260 Group Project
+
+This project is a web application built with ASP.NET Core MVC for tracking and managing fund positions.
+
+It allows users to view historical fund data, refresh and store the latest data from external sources, and work with financial records through a structured backend connected to a PostgreSQL database.
+
+The application follows a vertical slice architecture and focuses on clean separation of concerns, testability, and maintainable code structure.
+
 Repository containing group project of team-1.
 
-# Git hooks
+> Built with **.NET 10**
+
+---
+
+## Git Hooks
+
 Use the repository hooks for commit message validation, linting, and pre-push tests.
 
-```sh
-git config core.hooksPath .githooks
-```
+    git config core.hooksPath .githooks
+
+### Commit Message Format
 
 Commit subject must match:
+
 - `<command>(us[0-9]+): text`
 - allowed commands: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `build`, `perf`, `revert`
 - example: `feat(us3): add CI workflow`
 
-Pre-push hook behavior:
+### Pre-push Hook Behavior
+
 - runs `dotnet test PV260.ArkFundsTracker.sln --configuration Release --nologo`
 - blocks push if tests fail
 
-# Milestone 1
+---
+
+## Milestone 1
+
 All the artifacts required for `milestone-1` are located in `doc/` folder:
 
 - Big Picture Event Storming (`doc/big_picture.png`)
@@ -25,133 +42,173 @@ All the artifacts required for `milestone-1` are located in `doc/` folder:
 - User Stories (`doc/user_stories.md`)
 - Estimations of User Stories (`doc/estimations.md`)
 
-# Milestone 2
+---
 
-## US3 Project Setup & MVC Infrastructure
-The ASP.NET Core MVC solution skeleton is located in `src/PV260.ArkFundsTracker.Web`.
+## Milestone 2
 
-## US4 Database Schema & PostgreSQL Configuration
-Project uses PostgreSQL database.
-Connection string key used by the app is `ConnectionStrings:Default`.
+### US3 Project Setup & MVC Infrastructure
 
-### Configuration model
-- `appsettings.json` and `appsettings.Production.json` keep `ConnectionStrings:Default` empty by default.
-- `appsettings.Development.json` contains the local host-run development connection string.
-- Docker Compose uses `.env` for container startup values and sets `ConnectionStrings__Default` for the web container.
+The ASP.NET Core MVC solution skeleton is located in:
 
-### Development connection string
+    src/PV260.ArkFundsTracker.Web
+
+---
+
+### US4 Database Schema & PostgreSQL Configuration
+
+Project uses PostgreSQL database.  
+Connection string key used by the app is:
+
+    ConnectionStrings:Default
+
+---
+
+### Configuration Model
+
+- `appsettings.json` and `appsettings.Production.json` keep `ConnectionStrings:Default` empty by default
+- `appsettings.Development.json` contains the local host-run development connection string
+- Docker Compose uses `.env` for container startup values and sets `ConnectionStrings__Default` for the web container
+
+---
+
+### Development Connection String
+
 `src/PV260.ArkFundsTracker.Web/appsettings.Development.json` currently uses:
 
-```json
-"ConnectionStrings": {
-  "Default": "Host=localhost;Port=5434;Database=arkfundsDB;Username=postgres;Password=password123"
-}
-```
+    {
+      "ConnectionStrings": {
+        "Default": "Host=localhost;Port=5434;Database=arkfundsDB;Username=postgres;Password=password123"
+      }
+    }
 
 If needed, you can still override this value using `ConnectionStrings__Default` environment variable or `dotnet user-secrets`.
 
-### Configure environment variables via .env
+---
+
+### Configure Environment Variables via `.env`
+
 Use the sample file and create your local `.env`:
 
-```powershell
-Copy-Item .env.example .env
-```
+    Copy-Item .env.example .env
 
 `.env` is used by Docker Compose to configure:
+
 - PostgreSQL credentials and port
 - `APP_ENVIRONMENT` to switch between `Development` and `Production`
 
-`.env` values are for Compose-run containers. Local host-run (`dotnet run`) uses `appsettings.Development.json`
-or optional user-secrets overrides.
+`.env` values are for Compose-run containers.  
+Local host-run (`dotnet run`) uses `appsettings.Development.json` or optional user-secrets overrides.
 
 Default PostgreSQL image is pinned to `postgres:17` via `POSTGRES_IMAGE` to avoid `postgres:latest` major-upgrade surprises during local development.
 
-`dotnet run` uses the connection string from `appsettings.Development.json` by default.
+`dotnet run` uses the connection string from `appsettings.Development.json` by default.  
 For Docker Compose, the web container uses the `db` service name internally and sets `ConnectionStrings__Default` itself.
 
-### Vertical Slice structure
-- `Slices/Home/` - Home feature (controller, view model, and views)
-- `Slices/Common/` - shared contracts/views (error model + error view)
-- `Slices/FundPosition/` - FundPosition (entity model)
-- `Slices/TimestampNav/` - TimestampNav (controller, view model, services, and view) for timestamps compare
-- `Infrastructure/DependencyInjection/` - startup registration extensions
-- `Infrastructure/Configuration/` - strongly typed options
-- `Infrastructure/Data/` - Database connection (DB context, entities configuration)
-- `Migrations/` - Migrations for database 
+---
 
-### Environment configuration
+### Vertical Slice Structure
+
+- `Slices/Home/` – Home feature (controller, view model, and views)
+- `Slices/Common/` – shared contracts/views (error model + error view)
+- `Slices/FundPosition/` – FundPosition (entity model)
+- `Infrastructure/DependencyInjection/` – startup registration extensions
+- `Infrastructure/Configuration/` – strongly typed options
+- `Infrastructure/Data/` – Database connection (DB context, entities configuration)
+- `Migrations/` – Migrations for database
+
+---
+
+### Environment Configuration
+
 Configuration files:
+
 - `src/PV260.ArkFundsTracker.Web/appsettings.json`
 - `src/PV260.ArkFundsTracker.Web/appsettings.Development.json`
 - `src/PV260.ArkFundsTracker.Web/appsettings.Production.json`
 
 `Application` options can be overridden by environment variables, e.g.:
+
 - `Application__Name`
 
 Database variables expected for Docker Compose setup:
+
 - `POSTGRES_PORT`
 - `POSTGRES_DB`
 - `POSTGRES_USER`
 - `POSTGRES_PASSWORD`
 
-Set runtime environment with `ASPNETCORE_ENVIRONMENT` (`Development`, `Production`, ...).
+Set runtime environment with:
 
-### Run locally
+    ASPNETCORE_ENVIRONMENT
+
+(e.g. `Development`, `Production`, ...)
+
+---
+
+### Run Locally
+
 Local non-Docker options:
+
 - Use `ConnectionStrings:Default` from `appsettings.Development.json` (default), or
-- override with `ConnectionStrings__Default` in your shell/IDE environment.
+- override with `ConnectionStrings__Default` in your shell/IDE environment
 
 Current local default connection string:
 
-```json
-"ConnectionStrings": {
-  "Default": "Host=localhost;Port=5434;Database=arkfundsDB;Username=postgres;Password=password123"
-}
-```
+    {
+      "ConnectionStrings": {
+        "Default": "Host=localhost;Port=5434;Database=arkfundsDB;Username=postgres;Password=password123"
+      }
+    }
 
-```powershell
-dotnet restore .\PV260.ArkFundsTracker.sln
-dotnet build .\PV260.ArkFundsTracker.sln
-dotnet ef database update --project .\src\PV260.ArkFundsTracker.Web
-dotnet run --project .\src\PV260.ArkFundsTracker.Web\PV260.ArkFundsTracker.Web.csproj
-```
+#### Windows
 
-```sh
-dotnet restore ./PV260.ArkFundsTracker.sln
-dotnet build ./PV260.ArkFundsTracker.sln
-dotnet ef database update --project ./src/PV260.ArkFundsTracker.Web
-dotnet run --project ./src/PV260.ArkFundsTracker.Web/PV260.ArkFundsTracker.Web.csproj
-```
+    dotnet restore .\PV260.ArkFundsTracker.sln
+    dotnet build .\PV260.ArkFundsTracker.sln
+    dotnet ef database update --project .\src\PV260.ArkFundsTracker.Web
+    dotnet run --project .\src\PV260.ArkFundsTracker.Web\PV260.ArkFundsTracker.Web.csproj
+
+#### macOS / Linux
+
+    dotnet restore ./PV260.ArkFundsTracker.sln
+    dotnet build ./PV260.ArkFundsTracker.sln
+    dotnet ef database update --project ./src/PV260.ArkFundsTracker.Web
+    dotnet run --project ./src/PV260.ArkFundsTracker.Web/PV260.ArkFundsTracker.Web.csproj
+
+---
 
 ### Run with Docker Compose
-Start app + database in Development mode (`docker-compose.yml`):
 
-```powershell
-Copy-Item .env.example .env
-docker compose up --build
-```
+#### Start app + database (Development)
 
-Compose-run web app connects to PostgreSQL using `Host=db;Port=5432` inside the Docker network.
+    Copy-Item .env.example .env
+    docker compose up --build
 
-Run in Production mode (same compose file, env-controlled):
+Compose-run web app connects to PostgreSQL using:
 
-```powershell
-(Get-Content .env) -replace '^APP_ENVIRONMENT=.*', 'APP_ENVIRONMENT=Production' | Set-Content .env
-docker compose up --build
-```
+    Host=db;Port=5432
 
-Start only PostgreSQL database (`docker-compose.db.yml`):
+inside the Docker network.
 
-```powershell
-Copy-Item .env.example .env
-docker compose -f docker-compose.db.yml up -d
-```
+---
+
+#### Run in Production mode
+
+    (Get-Content .env) -replace '^APP_ENVIRONMENT=.*', 'APP_ENVIRONMENT=Production' | Set-Content .env
+    docker compose up --build
+
+---
+
+#### Start only PostgreSQL database
+
+    Copy-Item .env.example .env
+    docker compose -f docker-compose.db.yml up -d
+
+---
 
 ## Testing
 
 Project includes automated tests for ingestion and audit logic.
 
-### Running tests
+### Running Tests
 
-```bash
-dotnet test
+    dotnet test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It allows users to view historical fund data, refresh and store the latest data 
 
 The application follows a vertical slice architecture and focuses on clean separation of concerns, testability, and maintainable code structure.
 
-Repository containing group project of team-1.
+Repository containing the group project for team-1.
 
 > Built with **.NET 10**
 
@@ -22,7 +22,7 @@ Use the repository hooks for commit message validation, linting, and pre-push te
 
 Commit subject must match:
 
-- `<command>(us[0-9]+): text`
+- <type>(us<NUMBER>): message
 - allowed commands: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `build`, `perf`, `revert`
 - example: `feat(us3): add CI workflow`
 
@@ -46,22 +46,21 @@ All the artifacts required for `milestone-1` are located in `doc/` folder:
 
 ## Milestone 2
 
-### US3 Project Setup & MVC Infrastructure
+This milestone introduces the core application architecture, database integration, runtime configuration and tests.
 
-The ASP.NET Core MVC solution skeleton is located in:
+### Project Structure
+
+The ASP.NET Core MVC solution is located in:
 
     src/PV260.ArkFundsTracker.Web
 
----
+### Database
 
-### US4 Database Schema & PostgreSQL Configuration
+The project uses PostgreSQL.
 
-Project uses PostgreSQL database.  
-Connection string key used by the app is:
+Connection string key used by the application:
 
     ConnectionStrings:Default
-
----
 
 ### Configuration Model
 
@@ -89,33 +88,40 @@ If needed, you can still override this value using `ConnectionStrings__Default` 
 
 Use the sample file and create your local `.env`:
 
-#### Windows (PowerShell)
+#### Create `.env` file
+
+##### Windows (PowerShell)
     Copy-Item .env.example .env
 
-`.env` is used by Docker Compose to configure:
+##### macOS / Linux
+    cp .env.example .env
+
+The `.env` file is used by Docker Compose to configure:
 
 - PostgreSQL credentials and port
-- `APP_ENVIRONMENT` to switch between `Development` and `Production`
+- `APP_ENVIRONMENT` (e.g., `Development`, `Production`)
 
-`.env` values are for Compose-run containers.  
-Local host-run (`dotnet run`) uses `appsettings.Development.json` or optional user-secrets overrides.
+`.env` values apply only to containerized (Docker Compose) runs.  
+When running locally via `dotnet run`, the application uses `appsettings.Development.json` or optional user-secrets overrides.
 
-Default PostgreSQL image is pinned to `postgres:17` via `POSTGRES_IMAGE` to avoid `postgres:latest` major-upgrade surprises during local development.
+The PostgreSQL image is pinned to `postgres:17` via `POSTGRES_IMAGE` to avoid unexpected upgrades.
 
-`dotnet run` uses the connection string from `appsettings.Development.json` by default.  
-For Docker Compose, the web container uses the `db` service name internally and sets `ConnectionStrings__Default` itself.
+For Docker Compose, the web container connects to the database using the `db` service name and sets `ConnectionStrings__Default` internally.
 
 ---
 
 ### Vertical Slice Structure
 
-- `Slices/Home/` – Home feature (controller, view model, and views)
-- `Slices/Common/` – shared contracts/views (error model + error view)
-- `Slices/FundPosition/` – FundPosition (entity model)
-- `Infrastructure/DependencyInjection/` – startup registration extensions
+- `Slices/Home/` – Home feature (controller, view model, views)
+- `Slices/Common/` – shared contracts and views (e.g., error handling)
+- `Slices/FundPosition/` – fund position feature (data ingestion, storage, logic)
+- `Slices/TimestampNav/` – timestamp navigation and selection logic
+- `Slices/CronFetching/` – scheduled data fetching (background tasks)
+- `Infrastructure/DependencyInjection/` – service registration
 - `Infrastructure/Configuration/` – strongly typed options
-- `Infrastructure/Data/` – Database connection (DB context, entities configuration)
-- `Migrations/` – Migrations for database
+- `Infrastructure/Data/` – database context and configuration
+- `Infrastructure/Logging/` – structured logging (CSV parsing, fetching, cron jobs)
+- `Migrations/` – database migrations
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The application follows a vertical slice architecture and focuses on clean separ
 
 Repository containing group project of team-1.
 
-> Built with **.NET 10**
+> Built with **.NET 10** (SDK **10.0.100**, as pinned in `global.json`)
 
 ---
 


### PR DESCRIPTION
User Story 5: Project Documentation Foundation (Markdown)

As a developer, I want to establish standard Markdown documentation for the repository, so that all team members understand how to set up, run, and contribute to the project.
Acceptance Criteria

A comprehensive README.md is created at the repository root using standard Markdown formatting.
README.md includes local setup instructions, prerequisites (e.g., .NET SDK version), and commands to build and run the C# project.
A basic CONTRIBUTING.md is created detailing branch naming and pull request guidelines.
Out of Scope

Detailed API endpoint documentation (e.g., Swagger/OpenAPI setup) or end-user manuals.
Estimation

2 Points: Small task (~0.5 day).