### PR TITLE
Fix TimestampNav from ml-2 review

### DIFF
--- a/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampCompareServiceTests.cs
+++ b/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampCompareServiceTests.cs
@@ -4,7 +4,7 @@ using PV260.ArkFundsTracker.Web.Slices.FundPosition;
 using PV260.ArkFundsTracker.Web.Slices.TimestampNav;
 using PV260.ArkFundsTracker.Web.Slices.TimestampNav.TimestampCompare;
 
-namespace PV260.ArkFundsTracker.Tests.TimestampNavTests;
+namespace PV260.ArkFundsTracker.Tests.TimestampTests;
 
 public class TimestampCompareServiceTests
 {
@@ -25,7 +25,7 @@ public class TimestampCompareServiceTests
 
         var service = new TimestampCompareService(dbContext);
 
-        var result = await service.FillComparedPositionsList(firstDate);
+        var result = await service.FillComparedPositionsList(firstDate, CancellationToken.None);
 
         var nvda = Assert.Single(result, x => x.LastPosition?.Ticker == "NVDA");
         Assert.Equal(TimestampComparePositionState.New, nvda.PositionState);
@@ -51,7 +51,7 @@ public class TimestampCompareServiceTests
 
         var service = new TimestampCompareService(dbContext);
 
-        var result = await service.FillComparedPositionsList(firstDate);
+        var result = await service.FillComparedPositionsList(firstDate, CancellationToken.None);
 
         var roku = Assert.Single(result, x => x.FirstPosition?.Ticker == "ROKU");
         Assert.Equal(TimestampComparePositionState.Sold, roku.PositionState);
@@ -76,7 +76,7 @@ public class TimestampCompareServiceTests
 
         var service = new TimestampCompareService(dbContext);
 
-        var result = await service.FillComparedPositionsList(firstDate);
+        var result = await service.FillComparedPositionsList(firstDate, CancellationToken.None);
 
         var tsla = Assert.Single(result);
         Assert.Equal(TimestampComparePositionState.Same, tsla.PositionState);
@@ -99,7 +99,7 @@ public class TimestampCompareServiceTests
 
         var service = new TimestampCompareService(dbContext);
 
-        var result = await service.FillComparedPositionsList(firstDate);
+        var result = await service.FillComparedPositionsList(firstDate, CancellationToken.None);
 
         var tsla = Assert.Single(result);
         Assert.Equal(TimestampComparePositionState.Increased, tsla.PositionState);
@@ -122,7 +122,7 @@ public class TimestampCompareServiceTests
 
         var service = new TimestampCompareService(dbContext);
 
-        var result = await service.FillComparedPositionsList(firstDate);
+        var result = await service.FillComparedPositionsList(firstDate, CancellationToken.None);
 
         var tsla = Assert.Single(result);
         Assert.Equal(TimestampComparePositionState.Reduced, tsla.PositionState);
@@ -146,7 +146,7 @@ public class TimestampCompareServiceTests
         var service = new TimestampCompareService(dbContext);
 
         var exception = await Assert.ThrowsAsync<DataWithWrongValueException>(() =>
-            service.FillComparedPositionsList(firstDate));
+            service.FillComparedPositionsList(firstDate, CancellationToken.None));
 
         Assert.Equal("Shares of specific position can't be zero.", exception.Message);
     }
@@ -169,7 +169,7 @@ public class TimestampCompareServiceTests
 
         var service = new TimestampCompareService(dbContext);
 
-        var result = await service.FillComparedPositionsList(firstDate);
+        var result = await service.FillComparedPositionsList(firstDate, CancellationToken.None);
 
         var tsla = Assert.Single(result);
         Assert.Equal(50, tsla.SharesDifferencePercentage);
@@ -195,7 +195,7 @@ public class TimestampCompareServiceTests
 
         var service = new TimestampCompareService(dbContext);
 
-        var result = await service.FillComparedPositionsList(firstDate);
+        var result = await service.FillComparedPositionsList(firstDate, CancellationToken.None);
 
         var tsla = Assert.Single(result);
         Assert.Equal(20, tsla.SharesDifferencePercentage);

--- a/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampNavServiceTests.cs
+++ b/PV260.ArkFundsTracker.Tests/TimestampTests/TimestampNavServiceTests.cs
@@ -4,7 +4,7 @@ using PV260.ArkFundsTracker.Web.Slices.FundPosition;
 using PV260.ArkFundsTracker.Web.Slices.TimestampNav;
 using PV260.ArkFundsTracker.Web.Slices.TimestampNav.TimestampCompare;
 
-namespace PV260.ArkFundsTracker.Tests.TimestampNavTests;
+namespace PV260.ArkFundsTracker.Tests.TimestampTests;
 
 public class TimestampNavServiceTests
 {

--- a/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampCompare/TimestampCompareService.cs
+++ b/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampCompare/TimestampCompareService.cs
@@ -3,19 +3,13 @@ using PV260.ArkFundsTracker.Web.Infrastructure.Data;
 
 namespace PV260.ArkFundsTracker.Web.Slices.TimestampNav.TimestampCompare;
 
-public class TimestampCompareService
+public class TimestampCompareService(
+    AppDbContext db)
 {
-    private readonly AppDbContext _db;
-
-    public TimestampCompareService(AppDbContext db)
+    public async Task<List<TimestampCompareDto>> FillComparedPositionsList(DateOnly firstDate, CancellationToken ct)
     {
-        _db = db;
-    }
-
-    public async Task<List<TimestampCompareDto>> FillComparedPositionsList(DateOnly firstDate)
-    {
-        var firstPositionsList = await FetchFundPositionList(firstDate);
-        var lastPositionsList = await FetchFundPositionList(await GetLastPositionDate());
+        var firstPositionsList = await FetchFundPositionList(firstDate, ct);
+        var lastPositionsList = await FetchFundPositionList(await GetLastPositionDate(ct), ct);
 
         var firstDict = firstPositionsList
             .GroupBy(x => (x.Ticker, x.Company))
@@ -40,9 +34,9 @@ public class TimestampCompareService
         ];
     }
 
-    private async Task<DateOnly> GetLastPositionDate()
+    private async Task<DateOnly> GetLastPositionDate(CancellationToken ct)
     {
-        return await _db.FundPositions.MaxAsync(x => x.Date);
+        return await db.FundPositions.MaxAsync(x => x.Date, ct);
     }
 
     private static TimestampCompareDto ComparePositions(
@@ -52,17 +46,17 @@ public class TimestampCompareService
     {
         if (firstPosition == null)
         {
-            return FetchTimestampCompare(firstPosition, lastPosition, 0, TimestampComparePositionState.New);
+            return FillTimestampCompareDto(firstPosition, lastPosition, 0, TimestampComparePositionState.New);
         }
 
         if (lastPosition == null)
         {
-            return FetchTimestampCompare(firstPosition, lastPosition, -100, TimestampComparePositionState.Sold);
+            return FillTimestampCompareDto(firstPosition, lastPosition, -100, TimestampComparePositionState.Sold);
         }
 
         if (firstPosition.Shares == lastPosition.Shares)
         {
-            return FetchTimestampCompare(firstPosition, lastPosition, 0, TimestampComparePositionState.Same);
+            return FillTimestampCompareDto(firstPosition, lastPosition, 0, TimestampComparePositionState.Same);
         }
 
         if (firstPosition.Shares == 0)
@@ -75,10 +69,10 @@ public class TimestampCompareService
             ? TimestampComparePositionState.Increased
             : TimestampComparePositionState.Reduced;
 
-        return FetchTimestampCompare(firstPosition, lastPosition, sharesDiff, positionState);
+        return FillTimestampCompareDto(firstPosition, lastPosition, sharesDiff, positionState);
     }
 
-    private static TimestampCompareDto FetchTimestampCompare(TimestampNavPositionDto? firstPosition,
+    private static TimestampCompareDto FillTimestampCompareDto(TimestampNavPositionDto? firstPosition,
         TimestampNavPositionDto? lastPosition, decimal sharesDiff, TimestampComparePositionState positionState)
     {
         return new TimestampCompareDto
@@ -90,9 +84,9 @@ public class TimestampCompareService
         };
     }
 
-    private async Task<List<TimestampNavPositionDto>> FetchFundPositionList(DateOnly date)
+    private async Task<List<TimestampNavPositionDto>> FetchFundPositionList(DateOnly date, CancellationToken ct)
     {
-        return await _db.FundPositions
+        return await db.FundPositions
             .Select(x => new TimestampNavPositionDto
             {
                 Date = new DateOnly(x.Date.Year, x.Date.Month, x.Date.Day),
@@ -102,6 +96,6 @@ public class TimestampCompareService
                 WeightPercentage = x.WeightPercentage
             })
             .Where(x => x.Date == date)
-            .ToListAsync();
+            .ToListAsync(ct);
     }
 }

--- a/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampNavController.cs
+++ b/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampNavController.cs
@@ -2,19 +2,29 @@
 
 namespace PV260.ArkFundsTracker.Web.Slices.TimestampNav;
 
-public class TimestampNavController : Controller
+public class TimestampNavController(TimestampNavService timestampNavService) : Controller
 {
-    private readonly TimestampNavService _timestampNavService;
-
-    public TimestampNavController(TimestampNavService timestampNavService)
-    {
-        _timestampNavService = timestampNavService;
-    }
-
     [HttpGet]
     public async Task<IActionResult> Index(DateOnly? firstDate)
     {
-        var viewModel = await _timestampNavService.FillTimestampNavViewModel(firstDate);
-        return View(viewModel);
+        try
+        {
+            var viewModel = await timestampNavService.FillTimestampNavViewModel(firstDate, HttpContext.RequestAborted);
+            return View(viewModel);
+        }
+        catch (OperationCanceledException)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+        catch (DataWithWrongValueException ex)
+        {
+            TempData["ErrorMessage"] = "Fetched data has wrong values:" + ex.Message;
+        }
+        catch (Exception ex)
+        {
+            TempData["ErrorMessage"] = "Unexpected exception happened: " + ex.Message;
+        }
+
+        return RedirectToAction(nameof(Index));
     }
 }

--- a/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampNavService.cs
+++ b/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampNavService.cs
@@ -22,30 +22,15 @@ public class TimestampNavService(
         }
 
         var finalFirstDate = firstDate ?? dateList[1];
-        try
-        {
-            var timestampCompareList = await timestampCompareService.FillComparedPositionsList(finalFirstDate, ct);
-            var sortedTimestampCompareList = timestampCompareList
-                .OrderBy(x => x.PositionState).ThenByDescending(y => Math.Abs(y.SharesDifferencePercentage)).ToList();
+        var timestampCompareList = await timestampCompareService.FillComparedPositionsList(finalFirstDate, ct);
+        var sortedTimestampCompareList = timestampCompareList
+            .OrderBy(x => x.PositionState).ThenByDescending(y => Math.Abs(y.SharesDifferencePercentage)).ToList();
 
-            return new TimestampNavViewModel
-            {
-                SelectedDate = finalFirstDate,
-                DateList = dateList,
-                ComparedPositions = sortedTimestampCompareList
-            };
-        }
-        catch (OperationCanceledException ex)
+        return new TimestampNavViewModel
         {
-            throw new OperationCanceledException("In compare service: " + ex.Message);
-        }
-        catch (DataWithWrongValueException ex)
-        {
-            throw new DataWithWrongValueException("In compare service: " + ex.Message);
-        }
-        catch (Exception ex)
-        {
-            throw new DataWithWrongValueException("In compare service: " + ex.Message);
-        }
+            SelectedDate = finalFirstDate,
+            DateList = dateList,
+            ComparedPositions = sortedTimestampCompareList
+        };
     }
 }

--- a/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampNavService.cs
+++ b/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/TimestampNavService.cs
@@ -4,23 +4,17 @@ using PV260.ArkFundsTracker.Web.Slices.TimestampNav.TimestampCompare;
 
 namespace PV260.ArkFundsTracker.Web.Slices.TimestampNav;
 
-public class TimestampNavService
+public class TimestampNavService(
+    AppDbContext db,
+    TimestampCompareService timestampCompareService)
 {
-    private readonly AppDbContext _db;
-    private readonly TimestampCompareService _timestampCompareService;
-
-    public TimestampNavService(AppDbContext db, TimestampCompareService timestampCompareService)
+    public async Task<TimestampNavViewModel> FillTimestampNavViewModel(DateOnly? firstDate,
+        CancellationToken ct = default)
     {
-        _db = db;
-        _timestampCompareService = timestampCompareService;
-    }
-
-    public async Task<TimestampNavViewModel> FillTimestampNavViewModel(DateOnly? firstDate)
-    {
-        var dateList = await _db.FundPositions.Select(x => x.Date)
+        var dateList = await db.FundPositions.Select(x => x.Date)
             .Distinct()
             .OrderByDescending(x => x)
-            .ToListAsync();
+            .ToListAsync(ct);
 
         if (dateList.Count <= 1)
         {
@@ -28,15 +22,30 @@ public class TimestampNavService
         }
 
         var finalFirstDate = firstDate ?? dateList[1];
-        var timestampCompareList = await _timestampCompareService.FillComparedPositionsList(finalFirstDate);
-        var sortedTimestampCompareList = timestampCompareList
-            .OrderBy(x => x.PositionState).ThenByDescending(y => Math.Abs(y.SharesDifferencePercentage)).ToList();
-
-        return new TimestampNavViewModel
+        try
         {
-            SelectedDate = finalFirstDate,
-            DateList = dateList,
-            ComparedPositions = sortedTimestampCompareList
-        };
+            var timestampCompareList = await timestampCompareService.FillComparedPositionsList(finalFirstDate, ct);
+            var sortedTimestampCompareList = timestampCompareList
+                .OrderBy(x => x.PositionState).ThenByDescending(y => Math.Abs(y.SharesDifferencePercentage)).ToList();
+
+            return new TimestampNavViewModel
+            {
+                SelectedDate = finalFirstDate,
+                DateList = dateList,
+                ComparedPositions = sortedTimestampCompareList
+            };
+        }
+        catch (OperationCanceledException ex)
+        {
+            throw new OperationCanceledException("In compare service: " + ex.Message);
+        }
+        catch (DataWithWrongValueException ex)
+        {
+            throw new DataWithWrongValueException("In compare service: " + ex.Message);
+        }
+        catch (Exception ex)
+        {
+            throw new DataWithWrongValueException("In compare service: " + ex.Message);
+        }
     }
 }

--- a/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/Views/Index.cshtml
+++ b/src/PV260.ArkFundsTracker.Web/Slices/TimestampNav/Views/Index.cshtml
@@ -23,7 +23,7 @@
             <label>Decimal places for percentage: </label>
             <select id="decimalSelect" class="form-select w-25">
                 <option value="0">0</option>
-                <option value="2">2</option>
+                <option value="2" selected>2</option>
                 <option value="4">4</option>
                 <option value="6">6</option>
             </select>


### PR DESCRIPTION
Fix:
- chanege to primary constructor in all classes
- rename FetchTimestampCompare to FillTimestampCompareDto
- add cancellation token for db quary
- add exceptions handling to controller for autopropagating messeges